### PR TITLE
Add Repository Moved notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[Shopping Cart Plugins] – RazerMS WHMCS 
+===============
+
+<img src="https://user-images.githubusercontent.com/38641542/74416400-0d0da580-4e80-11ea-97da-1f0a349b5731.jpg">
+
 # 🚚 Repository Moved
 
 This repository has been moved to a new location and is no longer actively maintained.
@@ -12,13 +17,6 @@ Thank you for your support.
 
 ---
 
-
-
-[Shopping Cart Plugins] – RazerMS WHMCS 
-===============
-
-<img src="https://user-images.githubusercontent.com/38641542/74416400-0d0da580-4e80-11ea-97da-1f0a349b5731.jpg">
-
 Razer Merchant Services Plugin for WHMCS Shopping Cart developed by Razer Merchant Services R&D team.
 
 
@@ -32,3 +30,4 @@ Update Notice
 -----
 
 Latest WHMCS plugin moved to FiuuPayment - [Shopping-Cart-Plugins-Fiuu_WHMCS](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_WHMCS)
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# 🚚 Repository Moved
+
+This repository has been moved to a new location and is no longer actively maintained.
+
+👉 New repository: https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_WHMCS
+
+Please update your bookmarks, clone URLs, and CI/CD configurations accordingly.
+
+All future updates, bug fixes, and feature enhancements will be published in the new repository.
+
+Thank you for your support.
+
+---
+
 
 
 [Shopping Cart Plugins] – RazerMS WHMCS 

--- a/README.md
+++ b/README.md
@@ -14,20 +14,3 @@ Please update your bookmarks, clone URLs, and CI/CD configurations accordingly.
 All future updates, bug fixes, and feature enhancements will be published in the new repository.
 
 Thank you for your support.
-
----
-
-Razer Merchant Services Plugin for WHMCS Shopping Cart developed by Razer Merchant Services R&D team.
-
-
-Supported version
------------------
-
-WHMCS version v6.0.x and above
-
-
-Update Notice
------
-
-Latest WHMCS plugin moved to FiuuPayment - [Shopping-Cart-Plugins-Fiuu_WHMCS](https://github.com/FiuuPayment/Shopping-Cart-Plugins-Fiuu_WHMCS)
-


### PR DESCRIPTION
## Summary
- Added "Repository Moved" notice to the top of README
- Informs users that this repository has been migrated to the FiuuPayment organisation
- Directs users to update their bookmarks, clone URLs, and CI/CD configurations

## Related Issue
Fixes documentation migration requested in GitLab issue #17.